### PR TITLE
Add Kartveket security and developer portal info

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,6 @@
 # Virksomhetsapplikasjon:     ???
 
 # Automatic assign the following users as reviewers when a pull request is opened
-* @AreHHenriksen 
+* @AreHHenriksen
+
+/.security/ @ehelle 

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,0 +1,4 @@
+organization: Sjø
+product: Hydris
+repo_types: [Service]
+platforms: [VM_OS]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "hydris-pygeoapi"
+  tags:
+  - "internal"
+spec:
+  type: "service"
+  lifecycle: "production"
+  owner: "handsfree"
+  system: "hydris"


### PR DESCRIPTION
Legger til litt sikkerhetsinformasjon:
* `.security/description.yaml`: Litt metadata om repo'et
* `.github/CODEOWNERS`: Legger til Security Champion
* `catalog-info.yaml`: Info som [kartverket.dev](https://kartverket.dev) bruker å få legge til komponenten i oversikten